### PR TITLE
Update golang to 1.21

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -15,7 +15,7 @@ parts:
     source-type: git
     source-branch: add-missing-gets
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:


### PR DESCRIPTION
# Description

Updates golang to 1.21. This is required as some fixes from my fork use the `slices` library that was added to the standard library in 1.21.

This was tested locally with this [sdcore-nms PR](https://github.com/canonical/sdcore-nms/pull/90)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.