### PR TITLE
fix: Fix add subs to db patch

### DIFF
--- a/patches/02-add-subs-to-db-when-posted.patch
+++ b/patches/02-add-subs-to-db-when-posted.patch
@@ -16,7 +16,7 @@ index 6c2c038..7db20b0 100644
  		tmp := configmodels.SubsListIE{
 -			PlmnID: servingPlmnId.(string),
 -			UeId:   ueId.(string),
-+		    UeId: amData["ueID"].(string),
++		    UeId: amData["ueId"].(string),
 +		}
 +
 +		if servingPlmnId, plmnIdExists := amData["servingPlmnId"]; plmnIdExists {


### PR DESCRIPTION
# Description

Fixes typo in add-subs-to-db-when-posted patch.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.